### PR TITLE
accommodating a more standard import

### DIFF
--- a/ppmap.go
+++ b/ppmap.go
@@ -1,7 +1,8 @@
 package main
-import"os"
-import "bufio"
+
 import (
+    "os"
+    "bufio"
     "context"
     "math/rand"
     "log"


### PR DESCRIPTION
For a better reading, all packages must be grouped within the same import, although nothing changes if they are declared individually since the compiler reads it in the same way, but it is more idiomatic to do it this way especially for other developers